### PR TITLE
fix example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ references, and are not counted.
 ## Example Code
 
 ```rust
+use std::mem::size_of;
+
 use deepsize::DeepSizeOf;
 
 #[derive(DeepSizeOf)]
@@ -50,7 +52,7 @@ struct Test {
 fn main() {
     let object = Test {
         a: 15,
-        b: Box::new(b"Hello, Wold!"),
+        b: Box::new(*b"Hello, Wold!"),
     };
     
     assert_eq!(object.deep_size_of(), size_of::<Test>() + size_of::<u8>() * 12);


### PR DESCRIPTION
Hi.Thanks for writting this great crate.After copy-paste-run the  code in the readme, I got the error message blow:
```
b: Box::new(b"Hello, Wold!"),
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ expected slice `[u8]`, found `&[u8; 12]`
   |
```
so I just fix this error.Besides that, I also import `std::mem::size_of` in the example code. Whether to adopt the latter is up to you,but i think former should be fixed : )