### PR TITLE
Use const generics for arrays

### DIFF
--- a/src/default_impls.rs
+++ b/src/default_impls.rs
@@ -81,9 +81,9 @@ known_deep_size!(0;
 
 #[cfg(feature = "std")]
 mod strings {
-    use super::{DeepSizeOf, Context};
-    use std::ffi::{OsString, OsStr, CString, CStr};
-    use std::path::{PathBuf, Path};
+    use super::{Context, DeepSizeOf};
+    use std::ffi::{CStr, CString, OsStr, OsString};
+    use std::path::{Path, PathBuf};
 
     known_deep_size!(0; Path, OsStr, CStr);
 
@@ -107,7 +107,6 @@ mod strings {
         }
     }
 }
-
 
 impl DeepSizeOf for alloc::string::String {
     fn deep_size_of_children(&self, _: &mut Context) -> usize {
@@ -164,27 +163,11 @@ mod std_sync {
     }
 }
 
-macro_rules! deep_size_array {
-    ($($num:expr,)+) => {
-        deep_size_array!($($num),+);
-    };
-    ($($num:expr),+) => {
-        $(
-            impl<T: DeepSizeOf> DeepSizeOf for [T; $num] {
-                fn deep_size_of_children(&self, context: &mut Context) -> usize {
-                    self.as_ref().deep_size_of_children(context)
-                }
-            }
-        )+
-    };
+impl<T: DeepSizeOf, const N: usize> DeepSizeOf for [T; N] {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.as_ref().deep_size_of_children(context)
+    }
 }
-
-// Can't wait for const generics
-// A year and a half later, still waiting
-deep_size_array!(
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-    26, 27, 28, 29, 30, 31, 32
-);
 
 macro_rules! deep_size_tuple {
     ($(($n:tt, $T:ident)),+ ) => {

--- a/src/external_impls.rs
+++ b/src/external_impls.rs
@@ -133,7 +133,9 @@ mod indexmap_impl {
     // return the min of the capacity of the buckets list and the
     // capacity of the raw table.
     impl<K, V, S> DeepSizeOf for IndexMap<K, V, S>
-        where K: DeepSizeOf, V: DeepSizeOf
+    where
+        K: DeepSizeOf,
+        V: DeepSizeOf,
     {
         fn deep_size_of_children(&self, context: &mut Context) -> usize {
             let child_sizes = self.iter().fold(0, |sum, (key, val)| {
@@ -144,12 +146,13 @@ mod indexmap_impl {
         }
     }
     impl<K, S> DeepSizeOf for IndexSet<K, S>
-        where K: DeepSizeOf
+    where
+        K: DeepSizeOf,
     {
         fn deep_size_of_children(&self, context: &mut Context) -> usize {
-            let child_sizes = self.iter().fold(0, |sum, key| {
-                sum + key.deep_size_of_children(context)
-            });
+            let child_sizes = self
+                .iter()
+                .fold(0, |sum, key| sum + key.deep_size_of_children(context));
             let map_size = self.capacity() * (size_of::<(usize, K, ())>() + size_of::<usize>());
             child_sizes + map_size
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -54,6 +54,12 @@ fn slices() {
         DeepSizeOf::deep_size_of(&array),
         size_of::<usize>() * 2 + size_of::<[u32; 64]>()
     );
+
+    let array: Box<[u32]> = vec![0; 1000].into_boxed_slice();
+    assert_eq!(
+        DeepSizeOf::deep_size_of(&array),
+        size_of::<usize>() * 2 + size_of::<[u32; 1000]>()
+    );
 }
 
 // TODO: find edge cases


### PR DESCRIPTION
This allows to support more sizes than the predefined ones.

Some of the changes are unrelated and are were done by `cargo fmt`. If you'd like to have those come in a separate commit, happy to split them off.