### PR TITLE
feat: Add support for more packages to DeepSize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ arrayvec = { version = "^0.5", optional = true }
 smallvec = { version = "^1", optional = true }
 hashbrown = { version = "^0.9", optional = true }
 chrono = { version = "^0.4", optional = true }
+tokio = { version = "^1.1", optional = true, default-features = false }
+actix = { version = "^0.11.0", optional = true, default-features = false }
 
 [dev-dependencies]
 deepsize_derive = { path = "deepsize_derive", version = "0.1.1" }
@@ -28,3 +30,4 @@ deepsize_derive = { path = "deepsize_derive", version = "0.1.1" }
 default = ["std", "derive"]
 derive = ["deepsize_derive"]
 std = []
+tokio_net = ["tokio", "tokio/net"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ references, and are not counted.
 * `smallvec`: (version 1)
 * `hashbrown`: (version 0.9)
 * `chrono`: (version 0.4)
+* `actix`: (version 0.11)
+* `tokio`: (version 1.1)
 
 ## Example Code
 
@@ -54,7 +56,7 @@ fn main() {
         a: 15,
         b: Box::new(*b"Hello, Wold!"),
     };
-    
+
     assert_eq!(object.deep_size_of(), size_of::<Test>() + size_of::<u8>() * 12);
 }
 ```

--- a/src/external_impls.rs
+++ b/src/external_impls.rs
@@ -171,3 +171,26 @@ mod chrono_impl {
         {T: TimeZone} DateTime<T>, {T: TimeZone} Date<T>,
     );
 }
+
+#[cfg(feature = "tokio_net")]
+mod tokio_net_impl {
+    use crate::known_deep_size;
+    use tokio::net::{TcpListener, TcpStream, UdpSocket, UnixDatagram, UnixListener, UnixStream};
+
+    known_deep_size!(0;
+        TcpListener, TcpStream, UdpSocket,
+        UnixDatagram, UnixListener, UnixStream
+    );
+}
+
+#[cfg(feature = "actix")]
+mod actix_impl {
+    use crate::{Context, DeepSizeOf};
+    use actix::Addr;
+
+    impl<T: actix::Actor> DeepSizeOf for Addr<T> {
+        fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+            0
+        }
+    }
+}


### PR DESCRIPTION
I would like to add support for a few types from `tokio`, `actix`.

- `use tokio::net::TcpStream`
- `use actix::Addr`