### PR TITLE
Add support for arrays of sizes 64,65

### DIFF
--- a/src/default_impls.rs
+++ b/src/default_impls.rs
@@ -182,7 +182,7 @@ macro_rules! deep_size_array {
 // A year and a half later, still waiting
 deep_size_array!(
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-    26, 27, 28, 29, 30, 31, 32
+    26, 27, 28, 29, 30, 31, 32, 64, 65
 );
 
 macro_rules! deep_size_tuple {


### PR DESCRIPTION
Cryptographic keys like `Secp256K1PublicKey` have sizes of powers of two, or powers of two plus one. Let's add sizes 64,65.

Hopefully, Rust will support adding generics for integers in the future, and this will not longer be needed.