### PR TITLE
feat: Update `deepsize_derive` for `[dev-dependencies]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hashbrown = { version = "^0.9", optional = true }
 chrono = { version = "^0.4", optional = true }
 
 [dev-dependencies]
-deepsize_derive = { path = "deepsize_derive", version = "0.1.1" }
+deepsize_derive = { path = "deepsize_derive", version = "0.1.2" }
 
 [features]
 default = ["std", "derive"]


### PR DESCRIPTION
Maybe we should update deesize_derive to 0.1.2 for dev-dependencies