### PR TITLE
Use `as_bytes_with_nul` for deepsize of `CString`

### DIFF
--- a/src/default_impls.rs
+++ b/src/default_impls.rs
@@ -99,11 +99,7 @@ mod strings {
     }
     impl DeepSizeOf for CString {
         fn deep_size_of_children(&self, _: &mut Context) -> usize {
-            // This may cause a length check at runtime, but that
-            // doesn't seem avoidable.  This assumes that the allocation
-            // is the exact length of the string and the added null
-            // terminator.
-            self.as_bytes().len() + 1
+            self.as_bytes_with_nul().len()
         }
     }
 }


### PR DESCRIPTION
`CString::as_bytes_with_nul` is cheap to call - it directly returns a
reference to the inner byte slice.

`as_bytes_with_nul` performs  no allocations or validations.

See:

- https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_bytes_with_nul
- https://doc.rust-lang.org/src/std/ffi/c_str.rs.html#635-637

`as_bytes_with_nul` has been stable since Rust 1.0.0.