### PR TITLE
Specify correct minimum version of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ indexmap = { version = "^1", optional = true }
 arrayvec = { version = "^0.5", optional = true }
 smallvec = { version = "^1", optional = true }
 hashbrown = { version = "^0.9", optional = true }
-chrono = { version = "^0.4", optional = true }
+chrono = { version = "^0.4.15", optional = true }
 tokio = { version = "^1.1", optional = true, default-features = false }
 actix = { version = "^0.11.0", optional = true, default-features = false }
 


### PR DESCRIPTION
deepsize (with chrono feature) fails to build with chrono 0.4.13 (and 0.4.14 is yanked)